### PR TITLE
fix: Type '{ children: Element; }' has no properties 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,7 +138,7 @@ declare const Carousel: React.ComponentType<CarouselProps>
 
 declare const Modal: React.ComponentType<ModalProps>
 
-declare const ModalGateway: React.ComponentType<{}>
+declare const ModalGateway: React.ComponentType<{children:any}>
 
 export default Carousel
 export { Modal, ModalGateway }


### PR DESCRIPTION


<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

**Description of changes:**

**Related issues (if any):**

**Checks:**

- [ ] Please confirm `yarn run lint` ran successfully
- [ ] Please confirm that only `/src` and `/examples/src` are committed
- [ ] [if new feature] Please confirm that documentation was added to the README.md
